### PR TITLE
PHP script none argument

### DIFF
--- a/emulsify.php
+++ b/emulsify.php
@@ -307,12 +307,17 @@ function drush_emulsify($human_readable_name = NULL) {
 function drush_emulsify_create($human_readable_name, $machine_name, $description, $theme_path_passed) {
   $theme_dir = substr(getcwd(), 0, strpos(getcwd(), 'themes') + 6);
   if (!empty($theme_path_passed)) {
-    $theme_path = $theme_dir . DIRECTORY_SEPARATOR . $theme_path_passed . DIRECTORY_SEPARATOR . $machine_name;
+    if ($theme_path_passed === 'none') {
+      $theme_path = dirname(getcwd(), 1) . DIRECTORY_SEPARATOR . $machine_name;
+    }
+    else {
+      $theme_path = $theme_dir . DIRECTORY_SEPARATOR . $theme_path_passed . DIRECTORY_SEPARATOR . $machine_name;
 
-    // Phase: Validate theme dir with path is writeable.
-    $theme_dir_status = _emulsify_validate_path($theme_dir . DIRECTORY_SEPARATOR . $theme_path_passed);
-    if ($theme_dir_status !== TRUE) {
-      return _emulsify_notify_fail('', 'Failed on Phase: Validate theme dir is writeable.');
+      // Phase: Validate theme dir with path is writeable.
+      $theme_dir_status = _emulsify_validate_path($theme_dir . DIRECTORY_SEPARATOR . $theme_path_passed);
+      if ($theme_dir_status !== TRUE) {
+        return _emulsify_notify_fail('', 'Failed on Phase: Validate theme dir is writeable.');
+      }
     }
   }
   else {


### PR DESCRIPTION
**What & Why:**

When running the PHP script, you can set the path to "custom" (default), "contrib" or "none". There is a use-case for creating an Emulsify project outside of a Drupal install (installing as a standalone prototyping tool). Currently the "none" argument still searches for a Drupal path, and this PR changes it to not do that and instead install it in the parent directory of where it is run. This means that when you clone Emulsify, you can go into that original directory, run `php emulsify.php "New Theme" --machine-name new_theme --path none` and it will generate `new_theme` right alongside your original Emulsify instance. 

**How:**

_This script change is meant to only catch the "none" argument, but I want to make sure it doesn't impact the others._

**To Test:**
- [x] Run it as above outside a Drupal repo
- [ ] Run using the other options inside a Drupal repo and ensure they still work correctly
