### PR TITLE
Added support for png, jpg, and gif to the webpack ImageLoader.

### DIFF
--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -3,7 +3,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const globImporter = require('node-sass-glob-importer');
 
 const ImageLoader = {
-  test: /\.(svg)$/i,
+  test: /\.(png|svg|jpg|gif)$/i,
   exclude: /icons\/.*\.svg$/,
   loader: 'file-loader',
 };


### PR DESCRIPTION
**What:**

Updates the webpack loader to support png, jpg, and gif.

**Why:**

To stop errors :)

_Note: I followed the instructions from [here](https://webpack.js.org/guides/asset-management/#loading-images)_