### PR TITLE
GH-69: Fix node teaser heading path

### DIFF
--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -75,7 +75,7 @@
 
   {{ title_prefix }}
   {% if not page %}
-    {% include "@atoms/02-text/00-headings/_heading.twig" with {
+    {% include "@atoms/text/headings/_heading.twig" with {
       "heading_level": 2,
       "heading": label,
       "heading_url": url,


### PR DESCRIPTION
## Addresses https://github.com/emulsify-ds/emulsify-drupal/issues/69

**What:**

_Fixes Drupal node template teaser heading path_


**Why:**

_Path is broken_

**How:**

_code change_

**To Test:**
- [ ] Install in Drupal site and use the node template in a teaser and ensure heading shows up correctly and there are no errors
