### PR TITLE
Run Storybook with CI option

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "lint": "eslint ./components",
-    "storybook": "start-storybook -s ./dist, ./images -p 6006",
+    "storybook": "start-storybook --ci -s ./dist, ./images -p 6006",
     "build-storybook": "build-storybook -s ./dist,./images -o .out",
     "deploy-storybook": "storybook-to-ghpages -o .out",
     "babel": "npx babel components -w -d dist/js --ignore 'components/**/*.component.js','components/**/*.stories.js','components/**/*.min.js'",


### PR DESCRIPTION
**What:**

_Changes to CI option for start-storybook_

**Why:**

_1. It fixes [this](https://github.com/emulsify-ds/emulsify-drupal/issues/70). 2. I prefer it to not open browser_ ¯\_(ツ)_/¯

**To Test:**
- [x] Run an instance of storybook somewhere on your computer other than the instance you're going to test in.
- [x] In your `emulsify-drupal` instance, run `yarn develop` and ensure there is no conflict.
- [x] Tell me whether you like this option or not. 
