### PR TITLE
GH-46: Fix menu links to show attributes using link

### DIFF
--- a/components/02-molecules/menus/_menu-item.twig
+++ b/components/02-molecules/menus/_menu-item.twig
@@ -18,21 +18,26 @@
 {% endfor %}
 
 {% embed "@atoms/lists/_list-item.twig" with {
-  "list_item_label": item_label,
-  "li_base_class": item_base_class|default(menu_class ~ '__item'),
-  "li_modifiers": item_modifiers,
-  "li_blockname": item_blockname,
+  list_item_label: item_label,
+  li_base_class: item_base_class|default(menu_class ~ '__item'),
+  li_modifiers: item_modifiers,
+  li_blockname: item_blockname,
 } %}
   {% block list_item_content %}
-    {% include "@atoms/links/link/link.twig" with {
-      "link_content": item.title,
-      "link_url": item.url,
-      "link_base_class": item_base_class|default(menu_class ~ '__link'),
-      "link_modifiers": item_modifiers,
-    } %}
+    {# if drupal #}
+    {% if directory %}
+      {{ link(item.title, item.url, bem(item_base_class|default(menu_class ~ '__link'), item_modifiers)) }}
+    {% else %}
+      {% include "@atoms/links/link/link.twig" with {
+        link_content: item.title,
+        link_url: item.url,
+        link_base_class: item_base_class|default(menu_class ~ '__link'),
+        link_modifiers: item_modifiers,
+      } %}
+    {% endif %}
     {% if item.below %}
       <span class="expand-sub"></span>
-      {{ menus.menu_links(item.below, attributes, menu_level + 1, menu_class, menu_modifiers, menu_blockname, item_base_class, original_item_modifiers, item_blockname) }}
+      {{ menus.menu_links(item.below, attributes, menu_level + 1, menu_class, menu_modifiers, menu_blockname, item_base_class, original_item_modifiers, item_blockname, directory) }}
     {% endif %}
   {% endblock %}
 {% endembed %}

--- a/components/02-molecules/menus/_menu.twig
+++ b/components/02-molecules/menus/_menu.twig
@@ -23,8 +23,7 @@
   We call a macro which calls itself to render the full tree.
   @see http://twig.sensiolabs.org/doc/tags/macro.html
 #}
-
-{% macro menu_links(items, attributes, menu_level, menu_class, menu_modifiers, menu_blockname, item_base_class, item_modifiers, item_blockname) %}
+{% macro menu_links(items, attributes, menu_level, menu_class, menu_modifiers, menu_blockname, item_base_class, item_modifiers, item_blockname, directory) %}
   {% import _self as menus %}
   {% if items %}
 
@@ -58,4 +57,4 @@
 
 {% import _self as menus %}
 
-{{ menus.menu_links(items, attributes, 0, menu_class, menu_modifiers, menu_blockname, item_base_class, item_modifiers, item_blockname) }}
+{{ menus.menu_links(items, attributes, 0, menu_class, menu_modifiers, menu_blockname, item_base_class, item_modifiers, item_blockname, directory) }}

--- a/components/02-molecules/menus/main-menu/_02-main-menu-link.scss
+++ b/components/02-molecules/menus/main-menu/_02-main-menu-link.scss
@@ -17,7 +17,7 @@
     color: $gray-dark;
     display: inline-block;
     font-size: 1.1rem;
-    padding: $space $space $space $space;
+    padding: $space;
     text-transform: none;
     position: relative;
     width: auto;

--- a/components/02-molecules/menus/main-menu/_02-main-menu-link.scss
+++ b/components/02-molecules/menus/main-menu/_02-main-menu-link.scss
@@ -17,7 +17,7 @@
     color: $gray-dark;
     display: inline-block;
     font-size: 1.1rem;
-    padding: $space $space-double $space $space;
+    padding: $space $space $space $space;
     text-transform: none;
     position: relative;
     width: auto;
@@ -32,6 +32,7 @@
       color: $white;
       display: inline-block;
       content: '>';
+      margin-left: 0.5rem;
     }
 
     &--sub::after {


### PR DESCRIPTION
**What:**

_Resorts to using Drupal's `link` function as it is still required to gather all Drupal menu link attributes, but has to use a component fallback for Storybook._

**Why:**

_Drupal links should get more attributes by default (see pics below), and other modules like Menu Attributes interact with those attributes._

**To Test:**
- [ ] Verify [menu still works in Storybook](http://localhost:6006/?path=/story/molecules-menus--main)
- [ ] Verify the menu shows the "After" attributes below in Drupal

**Before in Drupal:**
<img width="383" alt="Screen Shot 2020-03-31 at 9 25 24 PM" src="https://user-images.githubusercontent.com/18293479/78096232-b3652a00-739e-11ea-9cec-a5aa320d6136.png">

**After in Drupal:**
<img width="618" alt="Screen Shot 2020-03-31 at 9 24 12 PM" src="https://user-images.githubusercontent.com/18293479/78096238-b8c27480-739e-11ea-9324-e9c5252eb24d.png">

