### PR TITLE
Fixed Storybook script to include images directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "lint": "eslint ./components",
-    "storybook": "start-storybook --ci -s ./dist, ./images -p 6006",
+    "storybook": "start-storybook --ci -s ./dist,./images -p 6006",
     "build-storybook": "build-storybook -s ./dist,./images -o .out",
     "deploy-storybook": "storybook-to-ghpages -o .out",
     "babel": "npx babel components -w -d dist/js --ignore 'components/**/*.component.js','components/**/*.stories.js','components/**/*.min.js'",


### PR DESCRIPTION
**What:**

I noticed while getting a new project set up that the `storybook` script in `package.json` had an extraneous space before `./images` in its list of static files to serve. This meant that when I tried to use an image housed within my `./images` directory as my theme's logo, or as part of a component, it failed to load. Removing this space resulted in the additional directory's static files being included.
