### PR TITLE
fix: bump corejs major version in preset-env config so it matches the installed version

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,11 @@
-module.exports = api => {
+module.exports = (api) => {
   api.cache(true);
 
   const presets = [
     [
       '@babel/preset-env',
       {
-        corejs: '2',
+        corejs: 3,
         useBuiltIns: 'usage',
       },
     ],


### PR DESCRIPTION
**What:**

Bumped the corejs major version config for `@babel/preset-env` so that it matches what is specified in `devDependencies` (which was recently updated).

**Why:**

Without this change, babel does not have the correct configuration. I merged some updates from `develop` into my working branch, where I have jest and babel-jest using the babel config, and jest was unable to run due to this major version mismatch. Anything else using this babel config is likely to experience similar issues.

**How:**

Incremented `@babel/preset-env`'s expected major corejs version so that it matches what is installed.

**To Test:**
- [x] `yarn build-storybook`: note that it builds without anything breaking.
