### PR TITLE
Add js-form-item/js-form-wrapper classes to fieldset

### DIFF
--- a/components/01-atoms/forms/_fieldset.twig
+++ b/components/01-atoms/forms/_fieldset.twig
@@ -20,7 +20,16 @@
  * @see template_preprocess_fieldset()
  */
 #}
-<fieldset{{ attributes.addClass('form-fieldset') }}>
+{%
+  set classes = [
+    'form-fieldset',
+    'js-form-item',
+    'form-item',
+    'js-form-wrapper',
+    'form-wrapper',
+  ]
+%}
+<fieldset{{ attributes.addClass(classes) }}>
   {%
     set legend_classes = [
       'h2',


### PR DESCRIPTION
**What:**

Adds `js-form-item` and `js-form-wrapper` (plus their non-JS equivalents) to the array of classes on the `fieldset` element. Also switched to a Twig `{% set %}` tag that includes the original `form-fieldset` class.

**Why:**

Two client sites using Emulsify as a base theme had Webforms with conditionally-visible fieldsets. Without these classes, those fieldsets are always hidden. Discussed via https://www.drupal.org/project/webform/issues/3158073