### PR TITLE
build: add husky and lint-staged, and configure prettier

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,6 @@ _why this change improves emulsify_
 _more details of changes made_
 
 **To Test:**
+
 - [ ] Step 1
 - [ ] Step 2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist
+.out
+.coverage
+node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ dist
 .out
 .coverage
 node_modules
+*.min.js

--- a/.storybook/_drupal.js
+++ b/.storybook/_drupal.js
@@ -2,19 +2,19 @@
 
 window.Drupal = { behaviors: {} };
 
-(function(Drupal, drupalSettings) {
-  Drupal.throwError = function(error) {
-    setTimeout(function() {
+(function (Drupal, drupalSettings) {
+  Drupal.throwError = function (error) {
+    setTimeout(function () {
       throw error;
     }, 0);
   };
 
-  Drupal.attachBehaviors = function(context, settings) {
+  Drupal.attachBehaviors = function (context, settings) {
     context = context || document;
     settings = settings || drupalSettings;
     const behaviors = Drupal.behaviors;
 
-    Object.keys(behaviors).forEach(function(i) {
+    Object.keys(behaviors).forEach(function (i) {
       if (typeof behaviors[i].attach === 'function') {
         try {
           behaviors[i].attach(context, settings);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,5 @@
 import { configure, addDecorator, addParameters } from '@storybook/react';
-import { useEffect } from "@storybook/client-api";
+import { useEffect } from '@storybook/client-api';
 import { withA11y } from '@storybook/addon-a11y';
 
 // Theming
@@ -14,9 +14,9 @@ addParameters({
 // GLOBAL CSS
 import '../components/style.scss';
 
-addDecorator(storyFn => {
+addDecorator((storyFn) => {
   useEffect(() => Drupal.attachBehaviors(), []);
-  return storyFn()
+  return storyFn();
 });
 
 addDecorator(withA11y);
@@ -38,7 +38,7 @@ import './_drupal.js';
 // automatically import all files ending in *.stories.js
 configure(require.context('../components', true, /\.stories\.js$/), module);
 
-// Below is for if Emulsify Gatsby style guide is being used 
+// Below is for if Emulsify Gatsby style guide is being used
 // // Gatsby's Link overrides:
 // // Gatsby defines a global called ___loader to prevent its method calls from creating console errors you override it here
 // global.___loader = {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,21 +10,21 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 Examples of behavior that contributes to a positive environment for our community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The project maintainers have adopted a Code of Conduct that we expect project pa
 Please also follow the issue template and pull request templates provided. See below for the correct places to post issues:
 
 1. [Emulsify Drupal](https://github.com/emulsify-ds/emulsify-drupal/issues)
-3. [Emulsify Twig Extensions](https://github.com/emulsify-ds/emulsify-twig-extensions/issues)
-4. [Emulsify Twig Drupal Module](https://www.drupal.org/project/issues/emulsify_twig)
+2. [Emulsify Twig Extensions](https://github.com/emulsify-ds/emulsify-twig-extensions/issues)
+3. [Emulsify Twig Drupal Module](https://www.drupal.org/project/issues/emulsify_twig)
 
 ## Author
 

--- a/components/00-base/01-colors/_00-colors-vars.scss
+++ b/components/00-base/01-colors/_00-colors-vars.scss
@@ -1,6 +1,6 @@
-// Color variables - it is better to use the colors in 
+// Color variables - it is better to use the colors in
 // components/00-base/01-colors/_01-colors-used.scss rather than
-// these colors directly. 
+// these colors directly.
 
 // Grayscale
 $white: white;

--- a/components/00-base/02-motion/_motion.scss
+++ b/components/00-base/02-motion/_motion.scss
@@ -2,8 +2,13 @@
 $transition-duration-base: 0.3s;
 $transition-timing-function-base: ease-in-out;
 
-@mixin transition($transition-property: all, $transition-duration: $transition-duration-base, $transition-timing-function: $transition-timing-function-base) {
-  transition: $transition-property $transition-duration $transition-timing-function;
+@mixin transition(
+  $transition-property: all,
+  $transition-duration: $transition-duration-base,
+  $transition-timing-function: $transition-timing-function-base
+) {
+  transition: $transition-property $transition-duration
+    $transition-timing-function;
 }
 
 // Demo UI
@@ -38,12 +43,12 @@ $transition-timing-function-base: ease-in-out;
   text-align: center;
 
   &::before {
-    content: "Duration: #{$transition-duration-base}";
+    content: 'Duration: #{$transition-duration-base}';
     display: block;
   }
 
   &::after {
-    content: "Timing Function: #{$transition-timing-function-base}";
+    content: 'Timing Function: #{$transition-timing-function-base}';
   }
 
   span {
@@ -65,12 +70,12 @@ $transition-timing-function-base: ease-in-out;
   @include transition(transform, 0.4s, ease-in);
 
   &::before {
-    content: "Duration: 0.4s";
+    content: 'Duration: 0.4s';
     display: block;
   }
 
   &::after {
-    content: "Timing Function: ease-in";
+    content: 'Timing Function: ease-in';
   }
 
   &:hover {
@@ -82,12 +87,12 @@ $transition-timing-function-base: ease-in-out;
   @include transition(transform, 0.2s, linear);
 
   &::before {
-    content: "Duration: 0.2s";
+    content: 'Duration: 0.2s';
     display: block;
   }
 
   &::after {
-    content: "Timing Function: linear";
+    content: 'Timing Function: linear';
   }
 
   &:hover {
@@ -96,15 +101,15 @@ $transition-timing-function-base: ease-in-out;
 }
 
 .demo-motion--expand {
-  @include transition(transform, 0.3s, cubic-bezier(.17,.67,.83,.67));
+  @include transition(transform, 0.3s, cubic-bezier(0.17, 0.67, 0.83, 0.67));
 
   &::before {
-    content: "Duration: 0.3s";
+    content: 'Duration: 0.3s';
     display: block;
   }
 
   &::after {
-    content: "Timing Function: cubic-bezier(.17,.67,.83,.67)";
+    content: 'Timing Function: cubic-bezier(.17,.67,.83,.67)';
   }
 
   &:hover {

--- a/components/01-atoms/buttons/twig/button.yml
+++ b/components/01-atoms/buttons/twig/button.yml
@@ -1,2 +1,2 @@
-button_content: "Twig Button"
-button_url: "#"
+button_content: 'Twig Button'
+button_url: '#'

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -1,6 +1,6 @@
 name: Emulsify
 type: theme
-description: Theme using Storybook and component-driven development 
+description: Theme using Storybook and component-driven development
 base theme: stable
 core: 8.x
 
@@ -24,7 +24,7 @@ ckeditor_stylesheets:
 
 regions:
   header: Header
-  content: Content  # the content region is required
+  content: Content # the content region is required
   sidebar: 'Sidebar'
   footer: Footer
 

--- a/emulsify.libraries.yml
+++ b/emulsify.libraries.yml
@@ -13,7 +13,8 @@ main-menu:
 # See also components/01-atoms/images/icons/_icon.twig to remove attach_library.
 sprite:
   js:
-    components/01-atoms/images/icons/svgxuse.min.js: { attributes: { defer: true } }
+    components/01-atoms/images/icons/svgxuse.min.js:
+      { attributes: { defer: true } }
 
 tabs:
   js:

--- a/husky.config.js
+++ b/husky.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   hooks: {
-    'pre-commit': 'npm run lint-staged',
+    'pre-commit': 'npm run lint-staged ; npm run lint',
     'pre-push': 'npm run lint-staged ; npm run test',
   },
 };

--- a/husky.config.js
+++ b/husky.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  hooks: {
+    'pre-commit': 'npm run lint-staged',
+    'pre-push': 'npm run lint-staged ; npm run test',
+  },
+};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  '*.{js,yml,scss,md}': ['npm run lint', 'npm run format'],
+};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  '*.{js,yml,scss,md}': ['npm run lint', 'npm run format'],
+  '*.{js,yml,scss,md}': ['npm run format'],
 };

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "develop": "concurrently --raw \"npm run webpack\" \"npm run babel\" \"npm run storybook\"",
     "test": "jest --coverage",
     "coverage": "yarn test && open-cli .coverage/lcov-report/index.html",
-    "format": "yarn lint --fix ; prettier --write \"**/*.{js,yml,scss,md}\""
+    "format": "prettier --write \"**/*.{js,yml,scss,md}\"",
+    "lint-staged": "lint-staged"
   },
   "devDependencies": {
     "babel-jest": "^26.0.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "build": "npm run build-babel & npm run build-webpack",
     "develop": "concurrently --raw \"npm run webpack\" \"npm run babel\" \"npm run storybook\"",
     "test": "jest --coverage",
-    "coverage": "yarn test && open-cli .coverage/lcov-report/index.html"
+    "coverage": "yarn test && open-cli .coverage/lcov-report/index.html",
+    "format": "yarn lint --fix ; prettier --write \"**/*.{js,yml,scss,md}\""
   },
   "devDependencies": {
     "babel-jest": "^26.0.1",
@@ -88,7 +89,9 @@
     "core-js": "3.6.5",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
+    "husky": "^4.2.5",
     "jest": "^26.0.1",
+    "lint-staged": "^10.2.11",
     "open-cli": "^6.0.1",
     "pa11y": "^5.3.0",
     "prettier": "2.0.5"


### PR DESCRIPTION
**What:**

This introduces a few things:
 - husky: which allows for npm scripts to be run on commit/push/etc via githooks.
 - lint-staged: allows for only staged files to be linted/formatted on commit hooks. This is important, because formatting the entire codebase every time you commit will take way too long, and it will drive you up the wall.
 - prettier adjustments: I configured prettier correctly so that it will format js, md, scss, and yml files. I also added a `format` script that runs prettier against eligible files.

**NOTE**
eslint currently is not paying attention to the staged changes, it lints everything. This is necessary for the time being, because eslint needs some adjustment. It shouldn't be linting _only_ the `.components` directory, but rather the entire codebase. I'll see if I can sneak that into this PR before this gets reviewed, but this work is valuable on it's own, so I thought I'd throw up a PR.

**Why:**

 I noticed some formatting inconsistencies recently and thought it would be a good idea to automate formatting completely so that nobody has to be concerned with it anymore

**How:**

I added a few dependencies (described above) and added some configuration.

**To Test:**
- [x] Run `yarn format`, and note that prettier examines every eligible file.
- [x] Make a bogus change, and commit your change. Note that Husky spins up and runs eslint and prettier.
