### PR TITLE
Fix: Drupal Components module Drupal 9 requirement, jest ignore vendor directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/components": "^1.0",
+        "drupal/components": "2.0.0-beta3",
         "drupal/emulsify_twig": "^2.0"
     }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,5 @@ module.exports = {
       statements: 0,
     },
   },
-  testPathIgnorePatterns: ['<rootDir>/dist'],
+  testPathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/vendor'],
 };


### PR DESCRIPTION
- Adds support for D9 ready version of [Components](https://www.drupal.org/project/components) module
- Changes Jest testing config to ignore `/vendor` (Composer) directory
