### PR TITLE
Fixes #148: Add postcss.config.js to list  of files to copy 

### DIFF
--- a/emulsify.php
+++ b/emulsify.php
@@ -489,6 +489,7 @@ function _emulsify_get_files_to_copy() {
     'emulsify.libraries.yml',
     'emulsify.theme',
     'package.json',
+    'postcss.config.js',
     'prettier.config.js',
   );
   // If we would like to have a bare copy we use is slim option.


### PR DESCRIPTION
**What:**

Added the `postcss.config.js` file to the list of things to copy when running `php emulsify.php my_theme`

**Why:**

Builds on the fixes in #115 to allow IE11 compatibility, as raised in #148 

**How:**

Added the `postcss.config.js` file to `_emulsify_get_files_to_copy`

**To Test:**

- [ ] Create a new theme with `php emulsify.php my_theme_name`
- [ ] Verify `postcss.config.js` is in the newly-created custom theme.
