### PR TITLE
Update storybook config to remove unwanted padding.

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,7 +13,6 @@ import '../components/style.scss';
 import './_drupal.js';
 
 export const parameters = {
-  layout: 'fullscreen',
   options: {
     theme: emulsifyTheme,
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,6 +13,7 @@ import '../components/style.scss';
 import './_drupal.js';
 
 export const parameters = {
+  layout: 'fullscreen',
   options: {
     theme: emulsifyTheme,
   },

--- a/components/04-templates/layouts.stories.js
+++ b/components/04-templates/layouts.stories.js
@@ -10,7 +10,12 @@ import footerMenu from '../02-molecules/menus/inline/inline-menu.yml';
 /**
  * Storybook Definition.
  */
-export default { title: 'Templates/Layouts' };
+export default {
+  title: 'Templates/Layouts',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
 
 export const fullWidth = () => (
   <div
@@ -19,6 +24,7 @@ export const fullWidth = () => (
     }}
   />
 );
+
 export const withSidebar = () => (
   <div
     dangerouslySetInnerHTML={{

--- a/components/05-pages/content-types/content-types.stories.js
+++ b/components/05-pages/content-types/content-types.stories.js
@@ -12,7 +12,12 @@ import footerMenuData from '../../02-molecules/menus/inline/inline-menu.yml';
 /**
  * Storybook Definition.
  */
-export default { title: 'Pages/Content Types' };
+export default {
+  title: 'Pages/Content Types',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
 
 export const article = () => (
   <div

--- a/components/05-pages/landing-pages/landing-pages.stories.js
+++ b/components/05-pages/landing-pages/landing-pages.stories.js
@@ -12,7 +12,12 @@ import footerMenuData from '../../02-molecules/menus/inline/inline-menu.yml';
 /**
  * Storybook Definition.
  */
-export default { title: 'Pages/Landing Pages' };
+export default {
+  title: 'Pages/Landing Pages',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
 
 export const homePage = () => (
   <div


### PR DESCRIPTION
**What:**

Removes these annoying inline styles that prevent full-browser-width components from actually reaching the browser edges (I think this is new to Storybook 6)

![Screen Shot 2020-10-23 at 5 36 22 PM](https://user-images.githubusercontent.com/1663810/97059556-56a5a880-1556-11eb-9a8f-a9546926314a.png)

**Why:**

It was really annoying

**How:**

There's a config settings in Storybook ([Docs](https://storybook.js.org/docs/react/configure/story-layout))

**To Test:**

- [ ] Load a storybook instance without this setting, and see the extra padding
- [ ] Load a storybook instance with this setting, and see no extra padding
