### PR TITLE
158: add root: true to avoid parent directory warnings in Drupal

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,4 @@
+root: true
 extends:
   - airbnb
   - prettier


### PR DESCRIPTION
Fixes https://github.com/emulsify-ds/emulsify-drupal/issues/158

To Test:
- [ ] Use inside a Drupal project and ensure when installing and running you don't get errors or warnings about eslint config