### PR TITLE
remove README during custom theme creation

### DIFF
--- a/emulsify.php
+++ b/emulsify.php
@@ -422,7 +422,6 @@ function _emulsify_get_files_to_alter() {
     return array_merge($default_array, array(
       'components',
       'templates',
-      'README.md',
     ));
   }
 }


### PR DESCRIPTION
**What:**

_Addresses https://github.com/emulsify-ds/emulsify-drupal/issues/107 by copying over the README but leaving it as-is._

**To Test:**

- [ ] In a Drupal instance, run the PHP script using this branch of the Emulsify project and ensure everything runs correctly, but the README is only copied over and doesn't have awkward instances of your new theme name sprinkled throughout.
