### PR TITLE
123: Pager Twig fix (Drupal error)

### DIFF
--- a/components/02-molecules/pager/__snapshots__/pager.twig.test.js.snap
+++ b/components/02-molecules/pager/__snapshots__/pager.twig.test.js.snap
@@ -5,7 +5,7 @@ exports[`pager can render a pager 1`] = `
   
   
   <nav
-    aria-labelledby="pagination-heading0"
+    aria-labelledby=""
     class="pager"
     role="navigation"
   >
@@ -13,9 +13,9 @@ exports[`pager can render a pager 1`] = `
     
     <h4
       class="visually-hidden"
-      id="pagination-heading0"
+      id=""
     >
-      Pagination0
+      Pagination
     </h4>
     
     
@@ -173,7 +173,7 @@ exports[`pager can render a pager with ellipses 1`] = `
   
   
   <nav
-    aria-labelledby="pagination-heading2"
+    aria-labelledby=""
     class="pager"
     role="navigation"
   >
@@ -181,9 +181,9 @@ exports[`pager can render a pager with ellipses 1`] = `
     
     <h4
       class="visually-hidden"
-      id="pagination-heading2"
+      id=""
     >
-      Pagination2
+      Pagination
     </h4>
     
     
@@ -382,7 +382,7 @@ exports[`pager can render a pager with prev and next ellipses 1`] = `
   
   
   <nav
-    aria-labelledby="pagination-heading1"
+    aria-labelledby=""
     class="pager"
     role="navigation"
   >
@@ -390,9 +390,9 @@ exports[`pager can render a pager with prev and next ellipses 1`] = `
     
     <h4
       class="visually-hidden"
-      id="pagination-heading1"
+      id=""
     >
-      Pagination1
+      Pagination
     </h4>
     
     
@@ -632,7 +632,7 @@ exports[`pager can render a pager with prev ellipses 1`] = `
   
   
   <nav
-    aria-labelledby="pagination-heading3"
+    aria-labelledby=""
     class="pager"
     role="navigation"
   >
@@ -640,9 +640,9 @@ exports[`pager can render a pager with prev ellipses 1`] = `
     
     <h4
       class="visually-hidden"
-      id="pagination-heading3"
+      id=""
     >
-      Pagination3
+      Pagination
     </h4>
     
     

--- a/components/02-molecules/pager/pager.twig
+++ b/components/02-molecules/pager/pager.twig
@@ -32,8 +32,8 @@
 {% set pager__base_class = 'pager' %}
 
 {% if items %}
-  <nav {{ bem(pager__base_class) }} role="navigation" aria-labelledby="pagination-heading{{ pager__uid }}">
-    <h4 id="pagination-heading{{ pager__uid }}" {{ bem('visually-hidden') }}>{{ 'Pagination' ~ pager__uid|t }}</h4>
+  <nav {{ bem(pager__base_class) }} role="navigation" aria-labelledby="{{ heading_id }}">
+    <h4 id="{{ heading_id }}" {{ bem('visually-hidden') }}>{{ 'Pagination'|t }}</h4>
     <ul {{ bem('items', [], pager__base_class, ['js-pager__items']) }}>
       {# Print previous item if we are not on the first page. #}
       {% if items.previous %}


### PR DESCRIPTION
**What:**

_It appears Drupal's Stable theme may have updated a variable in the pager.twig, so we needed to update ours as well as it was throwing an error using an old variable. Addresses https://github.com/emulsify-ds/emulsify-drupal/issues/123_

**Why:**

_Fixes WSOD error in Drupal with pager on screen._

**How:**

_more details of changes made_

**To Test:**

- [ ] Verify inside a Drupal installation that the error is fixed when using a pager.
