### PR TITLE
Feat/75: Drupal module dependencies declared in theme's info.yml

### DIFF
--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -5,7 +5,7 @@ base theme: stable
 core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
-  - components:components (>=2.0.0-beta3)
+  - components:components (>=8.x-2.x)
   - emulsify_twig:emulsify_twig
 
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -4,6 +4,9 @@ description: Theme using Storybook and component-driven development
 base theme: stable
 core: 8.x
 core_version_requirement: ^8 || ^9
+dependencies:
+  - components:components (>=2.0.0-beta3)
+  - emulsify_twig:emulsify_twig
 
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)
 libraries:


### PR DESCRIPTION
**What:**

_Themes can now declare module dependencies, so this PR enables this feature. Addresses https://github.com/emulsify-ds/emulsify-drupal/issues/75_

**To Test:**

- [ ] Verify in a Drupal installation that it requires you to enable the modules before enabling the theme

Closes https://github.com/emulsify-ds/emulsify-drupal/issues/75