### PR TITLE
Feat/109: Remove 'Theme' from hardcoded into the palette heading

### DIFF
--- a/components/00-base/01-colors/colors.twig
+++ b/components/00-base/01-colors/colors.twig
@@ -10,7 +10,7 @@
     {% set palette_machine = palette.palette_heading|lower %}
     {% include "@atoms/text/headings/_heading.twig" with {
       heading_level: 3,
-      heading: palette.palette_heading ~ ' Theme',
+      heading: palette.palette_heading,
     } %}
     <ul {{ bem('list', [palette_machine], colors_base_class) }} data-theme="{{ palette_machine }}">
       {% for color in palette.colors %}


### PR DESCRIPTION
Addresses https://github.com/emulsify-ds/emulsify-drupal/issues/109

**To Test:**

- [ ] Run `yarn develop` and ensure that the word "Theme" has been removed from the Storybook UI in the colors section and that everything runs without issues
