### PR TITLE
fix: jest should ignore the .out directory when looking for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,9 @@ module.exports = {
       statements: 0,
     },
   },
-  testPathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/vendor'],
+  testPathIgnorePatterns: [
+    '<rootDir>/dist',
+    '<rootDir>/vendor',
+    '<rootDir>/.out',
+  ],
 };


### PR DESCRIPTION
**What:**

Adjusts Jest configuration so that it can ignore .test.js files that exist within the build destination folder.

**Why:**

Running `yarn test` while .test.js files exist within the build destination folder currently results in Jest picking up those files, and then failing the tests within them.

**How:**

Added the build destination directory to the list of folders for Jest to ignore.

**To Test:**

- [ ] Run `yarn test` after you've built the theme. Note that the tests pass, and no weird tests are pulled in.
