### PR TITLE
Adjust line length to prevent CI test failure

### DIFF
--- a/components/01-atoms/images/icons/icons.md
+++ b/components/01-atoms/images/icons/icons.md
@@ -8,7 +8,10 @@ We are using an SVG sprite generator (details [here](https://www.npmjs.com/packa
 
 **Usage**
 
-The SVG component is found here: `/components/01-atoms/images/icons/_icon.twig`. See available variables in that file as well as instructions for Drupal. Examples of usage below:
+The SVG component is found here: 
+`/components/_patterns/01-atoms/04-images/icons/_icon.twig`. 
+See available variables in that file 
+as well as instructions for Drupal. Examples of usage below:
 
 Simple: (no BEM renaming)
 
@@ -22,7 +25,8 @@ Simple: (no BEM renaming)
 
 ```
 <svg class="icon">
-  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/icons.svg#src--menu"></use>
+  <use xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xlink:href="/icons.svg#src--menu"></use>
 </svg>
 ```
 
@@ -40,6 +44,7 @@ Complex (BEM classes):
 
 ```
 <svg class="main-nav__toggle">
-  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/icons.svg#src--menu"></use>
+  <use xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xlink:href="/icons.svg#src--menu"></use>
 </svg>
 ```


### PR DESCRIPTION
**What:**

Adjusted documentation to prevent `static_tests` from failing due to "Line exceeds 80 characters" errors

**Why:**

When incorporating CI practices after creating a new Emulsify theme, the `icons.md` file fails `static_tests` (a default test at least from Pantheon Build Tools) because some line lengths are more than 80 characters. I've had to make this minor tweak on each Emulsify-based project I've started.