### PR TITLE
feat(components): Updates components from pinned version to semantic release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/components": "2.0.0-beta3",
+        "drupal/components": "^2.0",
         "drupal/emulsify_twig": "^2.0"
     }
 }


### PR DESCRIPTION
**What:**

Updates components from `2.0.0-beta3` to `^2.0`

**Why:**

- Drupal 9 requires 2.x of components
- So that we are updating to the latest stable release when available.

**How:**

Updated `composer.json` dependency.

**To Test:**

- [ ] Install this in a Drupal environemnt
- [ ] Run `yarn upgrade`, delete the `node_modules` or something similar to get the updated version of components.
- [ ] Verify everything still works as expected.
