### PR TITLE
Remove colors from --slim option to prevent errors during initial Storybook run

### DIFF
--- a/emulsify.php
+++ b/emulsify.php
@@ -500,7 +500,6 @@ function _emulsify_get_files_to_copy() {
   if (drush_get_option('slim') === TRUE) {
     return array_merge($default_array, array(
       'components/style.scss',
-      'components/00-base/01-colors',
     ));
   }
   else {


### PR DESCRIPTION
**What:**

_After running emulsify.php with the (possibly undocumented) --slim option I found that I would encounter errors on the first run of storybook due to missing components._

**Why:**

_At Bounteous we're re-evaluating our front end starter kit, so I'm taking another hands on spin around the Drupal component landscape (I have a habit of doing that anyway.) The audience for this is probably pretty small, but I personally see value in being able to spin up an Emulsify project with all of the tooling structure, but no existing opinions or styles or components._

**How:**

Was encountering this error when running storybook:

`ERROR in ./components/00-base/01-colors/colors.twig
Module not found: Error: Can't resolve '/Users/brianperry/repos/fe-starter-sandbox/web/themes/custom/emulsify_test/components/01-atoms/text/headings/_heading.twig' in '/Users/brianperry/repos/fe-starter-sandbox/web/themes/custom/emulsify_test/components/00-base/01-colors'
 @ ./components/00-base/01-colors/colors.twig 1:0-133
 @ ./components/00-base/01-colors/colors.stories.js
 @ ./components sync ^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)(?!\.)(?=.)[^/]*?\.stories\.js)$
 @ ./.storybook/generated-stories-entry.js
 @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/storybook-init-framework-entry.js ./node_modules/@storybook/addon-a11y/dist/a11yRunner.js-generated-other-entry.js ./node_modules/@storybook/addon-a11y/dist/a11yHighlight.js-generated-other-entry.js ./.storybook/preview.js-generated-config-entry.js ./.storybook/generated-stories-entry.js (webpack)-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined`

_Removing colors from the slim option resolved this error. It also made slim even slimmer._

**To Test:**

- [ ] `php emulsify.php "THEME NAME" --slim`
- [ ] Change to new theme directory
- [ ] `npm install`
- [ ] `npm run develop`
- [ ] The result should be an empty storybook that launches with no errors.

Thanks as always for the great work on this project.