### PR TITLE
Add flex-wrap to Storybook styles for icons

### DIFF
--- a/components/01-atoms/images/icons/_icons.scss
+++ b/components/01-atoms/images/icons/_icons.scss
@@ -1,6 +1,7 @@
 // Storybook styling
 .icons-demo {
   display: flex;
+  flex-wrap: wrap;
 
   .icon {
     height: 100px;


### PR DESCRIPTION
Just a minor quality-of-life adjustment I tend to make on new projects, so I thought I'd suggest it: for lengthier lists of icons, this wraps the list to multiple lines so that you can see more icons on the page, instead of them extending on a single line to the point where you have to scroll horizontally to see more of the list.