### PR TITLE
Update components Twig namespaces to reflect API changes

### DIFF
--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -41,22 +41,17 @@ logo: images/logo.png
 #   - '@stable/css/system/components/reset-appearance.module.css'
 
 # MUST install `components` module: `drush dl components && drush en components -y``
-component-libraries:
-  base:
-    paths:
+components:
+  namespaces:
+    base:
       - components/00-base
-  atoms:
-    paths:
+    atoms:
       - components/01-atoms
-  molecules:
-    paths:
+    molecules:
       - components/02-molecules
-  organisms:
-    paths:
+    organisms:
       - components/03-organisms
-  templates:
-    paths:
+    templates:
       - components/04-templates
-  pages:
-    paths:
+    pages:
       - components/05-pages


### PR DESCRIPTION
I noticed on a new project today that I was getting the following watchdog log entry:

_Components 8.x-1.x API is deprecated in components:8.x-2.0 and is removed from components:3.0.0. Update the trailhead_theme.info.yml file to replace the component-libraries.[namespace].paths data with components.namespaces.[namespace]. See https://www.drupal.org/node/3082817_

It looks like the structure of the Twig namespaces has changed slightly. This PR updates the `.info.yml` file to match the structure [documented on Drupal.org](https://www.drupal.org/docs/contributed-modules/components/registering-twig-namespaces). I changed this on my new project and it's working just fine, but haven't done much component work on it yet, so additional review is appreciated!