### PR TITLE
fix: update eslint-webpack-plugin configuration to only scope components

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = async ({ config }) => {
       quiet: false,
     }),
     new ESLintPlugin({
+      context: path.resolve(__dirname, '../', 'components'),
       extensions: ['js'],
     }),
   );


### PR DESCRIPTION
fix 211

fixes  `ERROR in No files matching '/home/XXXXXX/Downloads/emulsify-drupal/.storybook/storybook-init-framework-entry.js' were found` when running `yarn develop

**To Test:**

- [x] yarn develop
- [x] confirm no error 

more info in the issue: https://github.com/emulsify-ds/emulsify-drupal/issues/211#
