### PR TITLE
Add first and last items to Pager component

### DIFF
--- a/components/02-molecules/pager/pager-first-last.yml
+++ b/components/02-molecules/pager/pager-first-last.yml
@@ -1,0 +1,28 @@
+pager__uid: 1
+ellipses:
+  previous: true
+  next: true
+items:
+  first:
+    href: '#'
+    attributes: ''
+  last:
+    href: '#'
+    attributes: ''
+  previous:
+    href: '#'
+    attributes: ''
+  next:
+    href: '#'
+    attributes: ''
+  pages:
+    - href: '#'
+      attributes: ''
+    - href: '#'
+      attributes: ''
+    - href: '#'
+      attributes: ''
+    - href: '#'
+      attributes: ''
+    - href: '#'
+      attributes: ''

--- a/components/02-molecules/pager/pager.stories.js
+++ b/components/02-molecules/pager/pager.stories.js
@@ -4,6 +4,7 @@ import pagerData from './pager.yml';
 import pagerEllipsesData from './pager-ellipses.yml';
 import pagerPrevEllipsesData from './pager-prev-ellipses.yml';
 import pagerBothEllipsesData from './pager-both-ellipses.yml';
+import pagerFirstLastData from './pager-first-last.yml';
 
 /**
  * Storybook Definition.
@@ -18,3 +19,6 @@ export const withBoth = () => pager({ ...pagerData, ...pagerBothEllipsesData });
 
 export const withPrevious = () =>
   pager({ ...pagerData, ...pagerPrevEllipsesData });
+
+export const withFirstAndLast = () =>
+  pager({ ...pagerData, ...pagerFirstLastData });

--- a/components/02-molecules/pager/pager.twig
+++ b/components/02-molecules/pager/pager.twig
@@ -35,6 +35,15 @@
   <nav {{ bem(pager__base_class) }} role="navigation" aria-labelledby="{{ heading_id }}">
     <h4 id="{{ heading_id }}" {{ bem('visually-hidden') }}>{{ 'Pagination'|t }}</h4>
     <ul {{ bem('items', [], pager__base_class, ['js-pager__items']) }}>
+      {# Print first item. #}
+      {% if items.first %}
+        <li {{ bem('item', ['first'], pager__base_class) }}>
+          <a {{ bem('link', ['first'], pager__base_class) }} href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}" {{ items.first.attributes|without('href', 'title', 'rel') }}>
+            <span {{ bem('visually-hidden') }}>{{ 'First page'|t }}</span>
+            <span aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
       {# Print previous item if we are not on the first page. #}
       {% if items.previous %}
         <li {{ bem('item', ['prev'], pager__base_class) }}>
@@ -71,6 +80,15 @@
           <a {{ bem('link', ['next'], pager__base_class) }} href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
             <span {{ bem('visually-hidden') }}>{{ 'Next page'|t }}</span>
             <span aria-hidden="true">{{ items.next.text|default('Next ›'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print last item. #}
+      {% if items.last %}
+        <li {{ bem('item', ['last'], pager__base_class) }}>
+          <a {{ bem('link', ['last'], pager__base_class) }} href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}" {{ items.last.attributes|without('href', 'title', 'rel') }}>
+            <span {{ bem('visually-hidden') }}>{{ 'Last page'|t }}</span>
+            <span aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
           </a>
         </li>
       {% endif %}


### PR DESCRIPTION
I've noticed that, especially when building Views in Drupal that have full pagination, those pagers' First and Last items aren't rendered, only the Previous and Next items and the page numbers surrounding the current page. This adds those to the Pager Twig template, along with a variant in Storybook. (I used the full words and guillemets, but feel free to adjust how these get rendered if something else makes more sense alongside the arrows replacing the Previous and Next labels.)

![Screen Shot 2021-06-07 at 9 54 10 PM](https://user-images.githubusercontent.com/848721/121110341-248e4180-c7db-11eb-8e24-d37143d444ac.png)