### PR TITLE
fix: file.includes errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "twatch": "jest --no-coverage --watch --verbose",
     "coverage": "yarn test && open-cli .coverage/lcov-report/index.html",
     "format": "prettier --write \"**/*.{js,yml,scss,md}\"",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "postinstall": "npx patch-package"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.1.18",

--- a/patches/twig+1.15.4.patch
+++ b/patches/twig+1.15.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/twig/twig.js b/node_modules/twig/twig.js
+index 9d50c4b..16fe0d7 100644
+--- a/node_modules/twig/twig.js
++++ b/node_modules/twig/twig.js
+@@ -8266,7 +8272,7 @@ module.exports = function (Twig) {
+       }).then(function (fileName) {
+         var embedOverrideTemplate = new Twig.Template({
+           data: token.output,
+-          id: state.template.id,
++          id: `${state.template.id}-override`,
+           base: state.template.base,
+           path: state.template.path,
+           url: state.template.url,


### PR DESCRIPTION
**What:**

fix: file.includes errors

**Why:**

When you have components with the pattern of:

include > include > embed

you get an error about file.includes is not a function, this patch fixes this, it is from the upstream repo and is uncommitted.

**To Test:**

- [ ] Find a project with the errors and pull this code into it.
