### PR TITLE
 Add webpack-fix-style-only-entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "twig-loader": "https://github.com/fourkitchens/twig-loader",
     "webpack": "4.44.2",
     "webpack-cli": "^4.2.0",
+    "webpack-fix-style-only-entries": "^0.6.1",
     "webpack-merge": "^5.3.0"
   },
   "scripts": {

--- a/webpack/css.js
+++ b/webpack/css.js
@@ -1,1 +1,0 @@
-import '../components/style.scss';

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -3,6 +3,7 @@ const path = require('path');
 const webpack = require('webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const _MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 const _ImageminPlugin = require('imagemin-webpack-plugin').default;
 const _SpriteLoaderPlugin = require('svg-sprite-loader/plugin');
 const glob = require('glob');
@@ -31,6 +32,7 @@ const ProgressPlugin = new webpack.ProgressPlugin();
 
 module.exports = {
   ProgressPlugin,
+  FixStyleOnlyEntriesPlugin: new FixStyleOnlyEntriesPlugin(),
   MiniCssExtractPlugin,
   ImageminPlugin,
   SpriteLoaderPlugin,

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -41,6 +41,7 @@ module.exports = {
     ],
   },
   plugins: [
+    plugins.FixStyleOnlyEntriesPlugin,
     plugins.MiniCssExtractPlugin,
     plugins.ImageminPlugin,
     plugins.SpriteLoaderPlugin,

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -17,7 +17,7 @@ function getEntries(pattern) {
   });
 
   entries.svgSprite = path.resolve(webpackDir, 'svgSprite.js');
-  entries.css = path.resolve(webpackDir, 'css.js');
+  entries.css = path.resolve(webpackDir, '../components/style.scss');
 
   return entries;
 }


### PR DESCRIPTION
**What:**
Add [webpack-fix-style-only-entries](https://www.npmjs.com/package/webpack-fix-style-only-entries)

**Why:**
Removes extra generated JS files from style-only entries. This cleans up the repo of unneeded styles.js files.

**How to reproduce**

* Run: `npm run develop` on the main branch
* Look at the dist folder for the extra css.js file that is not used.
* Cancel `npm run develop`
* Pull in this branch
* Delete all contents in the dist folder
* Rerun `npm run develop`

