### PR TITLE
Webpack should not minify CSS and JS files when running npm run develop.

### DIFF
--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -37,7 +37,6 @@ const CSSLoader = {
         sourceMap: true,
         sassOptions: {
           importer: globImporter(),
-          outputStyle: 'compressed',
         },
       },
     },


### PR DESCRIPTION
**What:**
Remove `outputStyle: 'compressed'` from cssLoader.

**Why:**
Drupal expects un-minified CSS and right now, we are breaking Drupal coding standards. Drupal can minify, even in separate libraries.

**How:**
The cmd `npm run develop` will no longer minify CSS and JS files
the cmd `npm run build` will minify

**To Test:**

* [ ] Step 1: Run `npm run develop` verify the CSS and js files are not minified
* [ ] Step 2 Run `npm run build` verify the CSS and js files are minified.

