### PR TITLE
a11y: Replace hardcoded H4 in pager component

### DIFF
--- a/components/02-molecules/pager/pager.twig
+++ b/components/02-molecules/pager/pager.twig
@@ -32,8 +32,7 @@
 {% set pager__base_class = 'pager' %}
 
 {% if items %}
-  <nav {{ bem(pager__base_class) }} role="navigation" aria-labelledby="{{ heading_id }}">
-    <h4 id="{{ heading_id }}" {{ bem('visually-hidden') }}>{{ 'Pagination'|t }}</h4>
+  <nav {{ bem(pager__base_class) }} role="navigation" aria-label="{{ 'Pagination'|t }}">
     <ul {{ bem('items', [], pager__base_class, ['js-pager__items']) }}>
       {# Print first item. #}
       {% if items.first %}


### PR DESCRIPTION
The hardcoded H4 tends to violate heading structures on pages, and the aria-labelledby element can be replaced with an aria-label on the nav element. See also this related report in Drupal core: https://www.drupal.org/project/drupal/issues/3232222