### PR TITLE
Fixed incorrect npm script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier": "prettier --ignore-unknown \"./components/**/*.{js,yml,scss,md}\"",
     "prettier-fix": "prettier --write --ignore-unknown \"./components**/*.{js,yml,scss,md}\"",
     "storybook": "start-storybook --ci -s ./dist,./images -p 6006",
-    "storybook-build": "npm run build && storybook-build -s ./dist,./images -o .out",
+    "storybook-build": "npm run build && build-storybook -s ./dist,./images -o .out",
     "storybook-deploy": "storybook-to-ghpages -o .out",
     "test": "jest --coverage",
     "twatch": "jest --no-coverage --watch --verbose",


### PR DESCRIPTION
**What:**

The command "storybook-build" is not working because it is referencing itself.

**Why:**

Bug

**How:**

The correct storybook command is "build-storybook so the line should read:
`"storybook-build": "npm run build && build-storybook -s ./dist,./images -o .out",`

Fixes: https://github.com/emulsify-ds/emulsify-drupal/issues/240