### PR TITLE
Configure webpack to compile multiple css files

### DIFF
--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -10,7 +10,7 @@ const glob = require('glob');
 const imagePath = path.resolve(__dirname, '../images');
 
 const MiniCssExtractPlugin = new _MiniCssExtractPlugin({
-  filename: 'style.css',
+  filename: '[name].css',
   chunkFilename: '[id].css',
 });
 
@@ -35,7 +35,15 @@ module.exports = {
   ImageminPlugin,
   SpriteLoaderPlugin,
   CleanWebpackPlugin: new CleanWebpackPlugin({
+    protectWebpackAssets: false, // Required for removal of extra, unwanted dist/css/*.js files.
     cleanOnceBeforeBuildPatterns: ['!*.{png,jpg,gif,svg}'],
-    cleanAfterEveryBuildPatterns: ['remove/**', '!js', '!*.{png,jpg,gif,svg}'],
+    cleanAfterEveryBuildPatterns: [
+      'remove/**',
+      '!js',
+      'css/**/*.js', // Remove all unwanted, auto generated JS files from dist/css folder.
+      'css/**/*.js.map',
+      'css/style.*', // Remove duplicated dist/css/style.css and its css.map
+      '!*.{png,jpg,gif,svg}',
+    ],
   }),
 };

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -7,17 +7,36 @@ const webpackDir = path.resolve(__dirname);
 const rootDir = path.resolve(__dirname, '..');
 const distDir = path.resolve(rootDir, 'dist');
 
-function getEntries(pattern) {
+// Glob pattern for scss files that ignore file names prefixed with underscore.
+const scssPattern = path.resolve(rootDir, 'components/**/!(_*).scss');
+// Glob pattern for JS files.
+const jsPattern = path.resolve(
+  rootDir,
+  'components/**/!(*.stories|*.component|*.min|*.test).js',
+);
+
+// Prepare list of scss and js file for "entry".
+function getEntries(scssPattern, jsPattern) {
   const entries = {};
 
-  glob.sync(pattern).forEach((file) => {
+  // SCSS entries
+  glob.sync(scssPattern).forEach((file) => {
+    const filePath = file.split('components/')[1];
+    const newfilePath = `css/${filePath.replace('.scss', '')}`;
+    entries[newfilePath] = file;
+  });
+
+  // JS entries
+  glob.sync(jsPattern).forEach((file) => {
     const filePath = file.split('components/')[1];
     const newfilePath = `js/${filePath.replace('.js', '')}`;
     entries[newfilePath] = file;
   });
 
   entries.svgSprite = path.resolve(webpackDir, 'svgSprite.js');
-  entries.css = path.resolve(webpackDir, 'css.js');
+  // entries.css must renamed into entries.style in order to keep style.css file name.
+  // Since each css file in derives its name from own entries.property name.
+  entries.style = path.resolve(webpackDir, 'css.js');
 
   return entries;
 }
@@ -26,12 +45,7 @@ module.exports = {
   stats: {
     errorDetails: true,
   },
-  entry: getEntries(
-    path.resolve(
-      rootDir,
-      'components/**/!(*.stories|*.component|*.min|*.test).js',
-    ),
-  ),
+  entry: getEntries(scssPattern, jsPattern),
   module: {
     rules: [
       loaders.CSSLoader,


### PR DESCRIPTION
re #246

**What:**
Modify webpack config to compile multiple scss files into multiple css files while keeping the current, default style.css file in place.

**Why:**
This will allow developers more flexibility, ability to choose between consuming the single style.css or splitting it to multiple libraries.It also set a foundation for developing storybook components in isolation. 

**How:**
In webpack/webpack.common.js  file 
I modified getEntries function to process multiple scss files entries the same way it already does for JS files.
So it will output multiple css files into new dist/css folder  the same way it currently does with JS in dist/js folder

In webpack/plugins.js  file 
1.  I changed MiniCssExtractPlugin filename parameter to be dynamic, [name].css, instead of being hardcoded "style.css"
2. Configured CleanWebpackPlugin to remove all unwanted, auto generated JS files from dist/css folder and also the remove duplicated style.css that already exits as dist/style.css

**To Test:**
1. [x]  Make sure you have components in components folder and run "yarn develop"
2. [x]  Exemine dist/css fo find css file for each scss file inside components folder that is not sass partial (its filename is not prefixed with underscore)