### PR TITLE
Remove node_modules from .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 **/*.min.js
-node_modules


### PR DESCRIPTION
ESLint ignores the node_modules directory by default.