### PR TITLE
Remove node_modules directory from ignore files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 **/*.min.js
-node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 dist
 .out
 .coverage
-node_modules
 *.min.js

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
ESLint, Prettier, and Stylelint ignore the node_modules directory by
default.