### PR TITLE
Fix testing scripts

### DIFF
--- a/.storybook/setupTwig.js
+++ b/.storybook/setupTwig.js
@@ -31,8 +31,8 @@ const fetchVariantConfig = () => {
         directory: 'components/03-organisms',
       },
       {
-        name: 'pages',
-        directory: 'components/04-pages',
+        name: 'templates',
+        directory: 'components/04-templates',
       },
     ];
   }

--- a/.storybook/setupTwig.js
+++ b/.storybook/setupTwig.js
@@ -16,23 +16,23 @@ const fetchVariantConfig = () => {
     return [
       {
         name: 'base',
-        directory: './components/00-base',
+        directory: 'components/00-base',
       },
       {
         name: 'atoms',
-        directory: './components/01-atoms',
+        directory: 'components/01-atoms',
       },
       {
         name: 'molecules',
-        directory: './components/02-molecules',
+        directory: 'components/02-molecules',
       },
       {
         name: 'organisms',
-        directory: './components/03-organisms',
+        directory: 'components/03-organisms',
       },
       {
         name: 'pages',
-        directory: './components/04-pages',
+        directory: 'components/04-pages',
       },
     ];
   }

--- a/.storybook/setupTwig.test.js
+++ b/.storybook/setupTwig.test.js
@@ -23,10 +23,11 @@ describe('setupTwig', () => {
 
   it('exports emulsifys namespaces', () => {
     expect(namespaces).toEqual({
-      atoms: '../components/01-atoms',
-      molecules: '../components/02-molecules',
-      organisms: '../components/03-organisms',
-      templates: '../components/04-templates',
+      atoms: '.././components/01-atoms',
+      base: '.././components/00-base',
+      molecules: '.././components/02-molecules',
+      organisms: '.././components/03-organisms',
+      pages: '.././components/04-pages',
     });
   });
 });

--- a/.storybook/setupTwig.test.js
+++ b/.storybook/setupTwig.test.js
@@ -23,11 +23,11 @@ describe('setupTwig', () => {
 
   it('exports emulsifys namespaces', () => {
     expect(namespaces).toEqual({
-      atoms: '.././components/01-atoms',
-      base: '.././components/00-base',
-      molecules: '.././components/02-molecules',
-      organisms: '.././components/03-organisms',
-      pages: '.././components/04-pages',
+      atoms: '../components/01-atoms',
+      base: '../components/00-base',
+      molecules: '../components/02-molecules',
+      organisms: '../components/03-organisms',
+      pages: '../components/04-pages',
     });
   });
 });

--- a/.storybook/setupTwig.test.js
+++ b/.storybook/setupTwig.test.js
@@ -23,8 +23,8 @@ describe('setupTwig', () => {
 
   it('exports emulsifys namespaces', () => {
     expect(namespaces).toEqual({
-      atoms: '../components/01-atoms',
       base: '../components/00-base',
+      atoms: '../components/01-atoms',
       molecules: '../components/02-molecules',
       organisms: '../components/03-organisms',
       templates: '../components/04-templates',

--- a/.storybook/setupTwig.test.js
+++ b/.storybook/setupTwig.test.js
@@ -27,7 +27,7 @@ describe('setupTwig', () => {
       base: '../components/00-base',
       molecules: '../components/02-molecules',
       organisms: '../components/03-organisms',
-      pages: '../components/04-pages',
+      templates: '../components/04-templates',
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,12 @@
       "name": "emulsify-drupal",
       "version": "1.0.0",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
         "add-attributes-twig-extension": "^0.1.0",
         "bem-twig-extension": "^0.1.1",
         "normalize.css": "^8.0.1",
+        "regenerator-runtime": "^0.13.9",
         "twig-drupal-filters": "^3.1.0"
       },
       "devDependencies": {
@@ -44,9 +45,10 @@
         "eslint-webpack-plugin": "^2.5.4",
         "file-loader": "^6.2.0",
         "fs": "^0.0.1-security",
-        "husky": "^7.0.4",
+        "husky": "^7.0.0",
         "imagemin-webpack-plugin": "^2.4.2",
         "jest": "^26.6.3",
+        "js-yaml": "^3.14.1",
         "js-yaml-loader": "^1.2.2",
         "lint-staged": "^11.2.6",
         "mini-css-extract-plugin": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "add-attributes-twig-extension": "^0.1.0",
     "bem-twig-extension": "^0.1.1",
     "normalize.css": "^8.0.1",
+    "regenerator-runtime": "^0.13.9",
     "twig-drupal-filters": "^3.1.0"
   },
   "devDependencies": {

--- a/scripts/a11y.test.js
+++ b/scripts/a11y.test.js
@@ -1,3 +1,5 @@
+import 'regenerator-runtime/runtime';
+
 const mockExit = jest
   .spyOn(global.process, 'exit')
   .mockImplementation(() => {});
@@ -17,7 +19,7 @@ const {
   ignore,
   storybookBuildDir,
   pa11y: pa11yConfig,
-} = require('../a11y.config.js');
+} = require('../a11y.config');
 
 const STORYBOOK_BUILD_DIR = path.resolve(__dirname, '../', storybookBuildDir);
 const STORYBOOK_IFRAME = path.join(STORYBOOK_BUILD_DIR, 'iframe.html');


### PR DESCRIPTION
**What:**

This pull request makes several small updates to get tests to work appropriately.

**Why:**

Tests should pass. :)

**How:**

* setupTwig.test.js updated namespaces to the current list of namespaces.
* a11y.test.js had regenerator-runtime/runtime added to get the test to run correctly. (This resolution is from https://dev.to/hulyakarakaya/how-to-fix-regeneratorruntime-is-not-defined-doj.)

**To Test:**

- [x] Download this branch
- [x] Remove the `node_modules` folder and run `npm install` to get a fresh set of modules.
- [x] Run `npm test` to confirm that all tests pass.

This resolves #255.