### PR TITLE
Standardize on npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 # Ignore compiled files.
 dist
 
-# Yarn/NPM
+# npm
 node_modules
-yarn.lock
 
 # Storybook
 .out

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 
 # Yarn/NPM
 node_modules
+yarn.lock
 
 # Storybook
 .out

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "a11y": "npm run storybook-build && ./scripts/a11y.js -r",
     "build": "webpack --config ./webpack/webpack.prod.js",
     "commit": "git-cz",
-    "coverage": "yarn test && open-cli .coverage/lcov-report/index.html",
+    "coverage": "npm run test && open-cli .coverage/lcov-report/index.html",
     "develop": "concurrently --raw \"npm run webpack\" \"npm run storybook\"",
     "format": "npm run lint-fix; npm run prettier-fix",
     "lint": "npm run lint-js; npm run lint-styles",


### PR DESCRIPTION
**What:**

This pull request migrates yarn references to npm and blocks committing a yarn.lock file to the repo.

**Why:**

Using yarn and npm interchangeably is confusing, so we are standardizing on npm.

**How:**

Script references in package.json were converted from `yarn ...` to `npm run ...`.

**To Test:**

- [ ] Run `npm run coverage` and confirm that script runs. (Currently it will fail. See #256 for a fix.)
- [ ] Run `yarn` to create a `yarn.lock` file. Confirm that it is not being tracked by the repo.

Closes #250