### PR TITLE
Issue 75 drupal module dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,5 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "require": {
-        "drupal/components": "^2.1",
-        "drupal/emulsify_twig": "^2.0"
-    }
+    "prefer-stable": true
 }

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -5,6 +5,10 @@ base theme: stable9
 core: 8.x
 core_version_requirement: ^8 || ^9
 
+dependencies:
+  - drupal:components
+  - drupal:emulsify_twig
+
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)
 libraries:
   - 'emulsify/global'

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -6,8 +6,8 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 
 dependencies:
-  - drupal:components
-  - drupal:emulsify_twig
+  - drupal:components (^2.1)
+  - drupal:emulsify_twig (^2.0)
 
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)
 libraries:


### PR DESCRIPTION
**What:**

Adds module dependencies to info.yml file and removes references to those modules in composer.json file to reduce confusion. Addresses #75 

**Why:**

Prevents installation of the created Emulsify-based theme until the correct modules (components and emulsify_twig) are installed. This helps eliminate confusion if the theme doesn't work properly without these modules installed.

**How:**

Added the two required modules to the dependencies section of the emulsify.info.yml file and removed the two modules from the composer.json file.

**To Test:**

- [ ] Follow the [instructions here](https://docs.emulsify.info/emulsify-drupal/emulsify-drupal) to install the Emulsify theme, **EXCEPT** in step 1 replace the command with the following: ```emulsify init --starter https://github.com/emulsify-ds/emulsify-drupal.git --checkout issue-75-drupal-module-dependencies "My Awesome Theme"``` to test the version on that branch.
- [x] Before installing ```components``` and ```emulsify_twig``` modules, check Drupal appearance page to make sure the theme cannot be installed without those two modules being installed first.
- [x] Add the two modules to the system via composer ```composer require drupal/components drupal/emulsify_twig```
- [x] Clear Drupal cache and reload the Drupal appearance page to make sure the new theme can be installed.
