### PR TITLE
Update emulsify.info.yml and emulsify.libraries.yml to point styleshe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Emulsify is an open-source tool for creating design systems with reusable compon
 
 ### Storybook development, Webpack build, and Drupal 8 theme
 
-**Emulsify Drupal** provides a [Storybook](https://storybook.js.org/) component library, a [Webpack](https://webpack.js.org/) development environment, and a Drupal 8 starterkit theme. It can be used as a standalone prototyping tool or inside a Drupal installation.
+**Emulsify Drupal** provides a [Storybook](https://storybook.js.org/) component library, a [Webpack](https://webpack.js.org/) development environment, and a Drupal 8 starter kit theme. It can be used as a standalone prototyping tool or inside a Drupal installation.
 
 ## Documentation
 

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -21,7 +21,7 @@ libraries:
 
 # CKEditor stylesheet loads in wysiwyg to give content editors a better experience
 ckeditor_stylesheets:
-  - dist/style.css
+  - dist/css/style.css
 
 regions:
   header: Header

--- a/emulsify.libraries.yml
+++ b/emulsify.libraries.yml
@@ -1,7 +1,7 @@
 global:
   css:
     theme:
-      dist/style.css: {}
+      dist/css/style.css: {}
 
 main-menu:
   js:


### PR DESCRIPTION
…ets to dist/css/style.css after PR #247 changed where compiled styles are generated (webpack/webpack.common.js:25).

**What:**

Update the path for style.css in emulsify.info.yml and emulsify.libraries.yml.

**Why:**

After https://github.com/emulsify-ds/emulsify-drupal/pull/247/files was merged, new sites using the Emulsify  Drupal starter theme would not have the compiled styles applied to the Drupal site.

**To Test:**

- [ ] Create a new Drupal site
- [ ] Initiate an Emulsify theme with the emulsify-drupal starter 
- [ ] Compile theme
- [ ] Them should reflect styles in style.css
