### PR TITLE
Ignore config files for VSCode and JetBrains IDEs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules
 
 # System
 .DS_Store
+.idea
+.vscode
 
 # Git deploy
 .publish


### PR DESCRIPTION
**What:**

Ignore .idea and .vscode files from IDEs.

**Why:**

Prevents accidental IDE config from being pushed.


