### PR TITLE
fix: Compiling style.scss after PR #247.

### DIFF
--- a/webpack/css/style.js
+++ b/webpack/css/style.js
@@ -1,0 +1,1 @@
+import '../../components/style.scss';

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -34,9 +34,13 @@ function getEntries(scssPattern, jsPattern) {
   });
 
   entries.svgSprite = path.resolve(webpackDir, 'svgSprite.js');
-  // entries.css must renamed into entries.style in order to keep style.css file name.
-  // Since each css file in derives its name from own entries.property name.
-  entries.style = path.resolve(webpackDir, 'css.js');
+
+  // CSS Files.
+  glob.sync(`${webpackDir}/css/*js`).forEach((file) => {
+    const baseFileName = path.basename(file);
+    const newfilePath = `css/${baseFileName.replace('.js', '')}`;
+    entries[newfilePath] = file;
+  });
 
   return entries;
 }


### PR DESCRIPTION
**What:**

Update style.scss compiling to match docs for "In webpack.common.js replace" here https://docs.emulsify.info/supporting-projects/webpack-and-build

**Why:**

Compiling style.scss is broken after PR #247.
