### PR TITLE
fix: Missing style.css after PR #247.

### DIFF
--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -42,7 +42,6 @@ module.exports = {
       '!js',
       'css/**/*.js', // Remove all unwanted, auto generated JS files from dist/css folder.
       'css/**/*.js.map',
-      'css/style.*', // Remove duplicated dist/css/style.css and its css.map
       '!*.{png,jpg,gif,svg}',
     ],
   }),


### PR DESCRIPTION
**What:**

Drupal could not find style.css because it was being removed.

**Why:**

This PR fixes it so style.css does not get removed.

**How:**

Modified the "cleanAfterEveryBuildPatterns" array to remove the entry `'css/style.*'`.

**To Test:**

- [ ] Download this branch and get Emulsify setup
- [ ] Run `npm run develop`
- [ ] Confirm that `dist/style.css` exists
- [ ] In a Drupal installation, confirm that it is seeing `dist/style.css`
