### PR TITLE
Deprecating D8 and enabling D10

### DIFF
--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: Theme using Storybook and component-driven development
 base theme: stable9
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 
 dependencies:
   - drupal:components (^2.1)


### PR DESCRIPTION
**What:**

Enable starter to be D10 compatible.

**Why:**

Without this change, a manual change of the info.yml is necessary for D10.

**How:**

After using the change in this branch and the change here ( https://git.drupalcode.org/project/emulsify_twig/-/merge_requests/4 ) to emulsify_twig module , then Emulsify works with D10.

See this issues and explanation for dropping D8 here ( https://www.drupal.org/project/emulsify_twig/issues/3301353 )