### PR TITLE
fix: remove core key as it's deprecated

### DIFF
--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -2,7 +2,6 @@ name: Emulsify
 type: theme
 description: Theme using Storybook and component-driven development
 base theme: stable9
-core: 8.x
 core_version_requirement: ^9 || ^10
 
 dependencies:


### PR DESCRIPTION
**What:**

Removes `core` key in emulsify.info.yml so emulsify CLI install can complete

**Why:**

CLI install is currently broken due to the core key being present

