### PR TITLE
Update Emulsify Twig dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,9 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require": {
+        "drupal/components": "^3.0@beta",
+        "drupal/emulsify_twig": "^4.0"
+    }
 }

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -5,7 +5,7 @@ base theme: stable9
 core_version_requirement: ^9 || ^10
 
 dependencies:
-  - drupal:components (^2.1)
+  - drupal:components (^3.0)
   - drupal:emulsify_twig (^4.0)
 
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -46,15 +46,9 @@ logo: images/logo.png
 # MUST install `components` module: `drush dl components && drush en components -y``
 components:
   namespaces:
-    base:
-      - components/00-base
-    atoms:
-      - components/01-atoms
-    molecules:
-      - components/02-molecules
-    organisms:
-      - components/03-organisms
-    templates:
-      - components/04-templates
-    pages:
-      - components/05-pages
+    base: components/00-base
+    atoms: components/01-atoms
+    molecules: components/02-molecules
+    organisms: components/03-organisms
+    templates: components/04-templates
+    pages: components/05-pages

--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -6,7 +6,7 @@ core_version_requirement: ^9 || ^10
 
 dependencies:
   - drupal:components (^2.1)
-  - drupal:emulsify_twig (^2.0)
+  - drupal:emulsify_twig (^4.0)
 
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)
 libraries:


### PR DESCRIPTION
**What:**

Updates Emulsify Twig dependency to ^4.0 which is now the latest version of Emulsify Twig.

**Why:**

Emulsify Twig 4.0 is Drupal 10 ready and also works on Drupal 9. Drupal 8 support was dropped.

**How:**

Updated emulsify.info.yml with dependency change.

**To Test:**

- [x] Install new theme based on this branch from the project root: `emulsify init "My Awesome Theme" --checkout feat-update-emulsify-twig`
- [x] Install dependencies (if not already installed): `composer require 'drupal/components:^3.0@beta' && composer require drupal/emulsify_twig`
- [x] Enable dependencies (if not already enabled): `drush en components emulsify_twig -y`
- [x] Install compound from within the new theme directory: `emulsify system install compound`
- [x] Verify that Emulsify Twig is version 4.0 here: `/admin/modules`
- [x] Enable the new theme in the Drupal UI
- [x] Verify that the theme can be enabled with Emulsify Twig 4.0 as a dependency.

