### PR TITLE
Fix(stylelint issues): Adjusting stylelint rule settings.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,6 +7,26 @@
   ],
   "customSyntax": "postcss-scss",
   "rules": {
+    "at-rule-empty-line-before": [
+      "always",
+      {
+        "ignoreAtRules": [
+          "content",
+          "each",
+          "else",
+          "extend",
+          "forward",
+          "function",
+          "if",
+          "import",
+          "include",
+          "mixin",
+          "return",
+          "use",
+          "media"
+        ]
+      }
+    ],
     "at-rule-no-unknown": [
       true,
       {
@@ -27,9 +47,12 @@
       }
     ],
     "function-no-unknown": null,
-    "value-keyword-case": null,
+    "import-notation": null,
+    "media-feature-range-notation": null,
     "prettier/prettier": true,
+    "property-no-vendor-prefix": null,
     "selector-class-pattern": null,
-    "selector-not-notation": null
+    "selector-not-notation": null,
+    "value-keyword-case": null
   }
 }


### PR DESCRIPTION
## Summary

Since there was an update to Node 20, the Stylelin version were upgraded too, this is not happening on Compound, this PR fixes the new warnings the are being displayed because of those upgrades.

**This PR must be tested together with this [PR](https://github.com/emulsify-ds/compound/pull/104)**

## How to review this pull request

Create Drupal Project:
    `composer create-project drupal/recommended-project [PROJECT_NAME] --no-interaction `

Move into the project directory
    `cd [PROJECT_NAME]`

Install Emulsify client globally
    `npm install -g @emulsify/cli`

Initialize your theme with emulsify
    `emulsify init --checkout=fix-stylelint-issues "[THEME NAME]"`

Install the version of Drupal componentst works with Drupal 10
    `composer require 'drupal/components:^3.0@beta'  `

Install the version of emulsify_twig that work with Drupal 10
    `composer require 'drupal/emulsify_twig^4.0'`

Move into the theme directory
    `cd web/themes/custom/[THEME NAME]`

Install Compound System
    `emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout fix-stylelint-issues`

Verify storybook and scss compiling can run and there are no stylelint issues and warnings
    `npm install && npm run develop`
