### PR TITLE
feat: add version 5.0 as supported emulsify_twig

### DIFF
--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -6,7 +6,7 @@ core_version_requirement: ^9 || ^10
 
 dependencies:
   - drupal:components (^3.0)
-  - drupal:emulsify_twig (^4.0)
+  - drupal:emulsify_twig (^5.0)
 
 # Libraries (These are loaded on every page. Use https://www.drupal.org/developing/api/8/assets#twig whenever possible.)
 libraries:


### PR DESCRIPTION
**What:**
- Updates Emulsify Twig supported version to 5.0

**Why:**
- 4.x was deprecated due to dropping support for Drupal 9.x

**To Test:**

- [ ] Verify this is installed able with Emulsify Twig 5.x