### PR TITLE
fix: update Emulsify Tools to 1.x stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,18 +6,6 @@
     "license": "GPL-2.0-only",
     "authors": [
         {
-            "name": "Brian Lewis",
-            "email": "brian@fourkitchens.com"
-        },
-        {
-            "name": "Chris Martin",
-            "email": "chris.martin@fourkitchens.com"
-        },
-        {
-            "name": "Evan Willhite",
-            "email": "evan@fourkitchens.com"
-        },
-        {
             "name": "Randy Oest",
             "email": "randy@fourkitchens.com"
         },
@@ -37,7 +25,7 @@
     "require": {
         "drupal/core": "^10 || ^11",
         "drupal/components": "^3.0@beta",
-        "drupal/emulsify_tools": "^1.0.x-dev@dev"
+        "drupal/emulsify_tools": "^1.0"
     },
     "extra": {
         "drush": {


### PR DESCRIPTION
**This PR does the following:**
- Updates the Emulsify Tools dependency to the 1.x stable release.

### Notes:
- (optional) Document any intentionally unfinished parts or known issues within this PR

### Functional Testing:
- [x] Run `composer require 'drupal/emulsify:^5.0'` within a Drupal project. Verify 1.x stable of Emulsify Tools is installed.


