### PR TITLE
feat: add default main.js to config that passes an empty object

### DIFF
--- a/whisk/config/emulsify-core/storybook/main.js
+++ b/whisk/config/emulsify-core/storybook/main.js
@@ -1,0 +1,30 @@
+// Pass an empty configOverrides by default.
+const configOverrides = {};
+
+// Uncomment the following section to override the default Emulsify Core configuration.
+// Doing so is a complete override so no configuration from Emulsify Core's main.js will be inherited.
+// See https://storybook.js.org/docs/7/configure for details.
+// const configOverrides = {
+//   stories: [
+//     '../../../../components/**/*.stories.@(js|jsx|ts|tsx)',
+//   ],
+//   addons: [
+//     '../../../@storybook/addon-a11y',
+//     '../../../@storybook/addon-links',
+//     '../../../@storybook/addon-essentials',
+//     '../../../@storybook/addon-themes',
+//     '../../../@storybook/addon-styling-webpack'
+//   ],
+//   core: {
+//     builder: 'webpack5',
+//   },
+//   framework: {
+//     name: '@storybook/html-webpack5',
+//     options: {},
+//   },
+//   docs: {
+//     autodocs: true,
+//   },
+// };
+
+module.exports = {configOverrides};


### PR DESCRIPTION
**This PR does the following:**
- Set up a default main.js that is consumed by Emulsify Core and gives an example of storybook config. 
  
### Related Issue(s)
- None

### Functional Testing:
- [ ] Setup a new theme or add this file to an existing Emulsify 5.x project
- [ ] Update Emulsify Core to 1.2.0
- [ ] Uncomment the provided `configOverrides` and implement a config change. Example: add the following after the `docs: {}` 
```
managerHead: (head) => `
    ${head}
    <style>
      :root {
        --colors-emulsify-blue-100: #e6f5fc;
        --colors-emulsify-blue-200: #CCECFA;
        --colors-emulsify-blue-300: #99D9F4;
        --colors-emulsify-blue-400: #66c5ef;
        --colors-emulsify-blue-500: #33b2e9;
        --colors-emulsify-blue-600: #009fe4;
        --colors-emulsify-blue-700: #007FB6;
        --colors-emulsify-blue-800: #005f89;
        --colors-emulsify-blue-900: #00405b;
        --colors-emulsify-blue-1000: #00202e;
        --colors-purple: #8B1E7E;
      }
    </style>
  `,
  ```
- [ ] Run `npm run develop` to startup storybook. Inspect the main `<head>` of the source and verify the inline styles defined above are now rendered on the page.


