### PR TITLE
EMULSIF-362: update package to use emulsify 2.2.3. Update namespaces

### DIFF
--- a/emulsify.info.yml
+++ b/emulsify.info.yml
@@ -20,12 +20,3 @@ regions:
   footer: Footer
 
 logo: assets/images/logo.svg
-
-components:
-  namespaces:
-    base: components/00-base
-    atoms: components/01-atoms
-    molecules: components/02-molecules
-    organisms: components/03-organisms
-    templates: components/04-templates
-    pages: components/05-pages

--- a/whisk/package.json
+++ b/whisk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whisk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Storybook development + Webpack Build",
   "keywords": [
     "component library",
@@ -17,7 +17,7 @@
     "build": "webpack --config node_modules/@emulsify/core/config/webpack/webpack.prod.js",
     "build-dev": "webpack --config node_modules/@emulsify/core/config/webpack/webpack.dev.js",
     "coverage": "npm run test && open-cli .coverage/lcov-report/index.html",
-    "develop": "concurrently --raw \"npm run webpack\" \"npm run storybook\"",
+    "develop": "npm run build-dev && concurrently --raw \"npm run webpack\" \"npm run storybook\"",
     "format": "npm run lint-fix; npm run prettier-fix",
     "husky:commit-msg": "commitlint --edit $1",
     "husky:pre-commit": "lint-staged",
@@ -31,14 +31,14 @@
     "storybook": "storybook dev -c node_modules/@emulsify/core/.storybook --ci -p 6006",
     "storybook-build": "npm run build && storybook build -c node_modules/@emulsify/core/.storybook -o .out",
     "storybook-deploy": "storybook-to-ghpages -o .out",
-    "style-dictionary:build": "node ./tokens/tokensTransform.js",
+    "style-dictionary:build": "node ./src/tokens/tokensTransform.mjs",
     "test": "jest --coverage  --config ./config/jest.config.js",
     "tokens:build": "npm run tokens:transform && npm run style-dictionary:build",
-    "tokens:transform": "token-transformer ./tokens/figma.tokens.json ./tokens/transformed.tokens.json",
+    "tokens:transform": "token-transformer ./src/tokens/figma.tokens.json ./src/tokens/transformed.tokens.json",
     "twatch": "jest --no-coverage --watch --verbose",
     "webpack": "webpack --watch --config node_modules/@emulsify/core/config/webpack/webpack.dev.js"
   },
   "dependencies": {
-    "@emulsify/core": "^2.2.3"
+    "@emulsify/core": "^2.4.2"
   }
 }

--- a/whisk/package.json
+++ b/whisk/package.json
@@ -39,6 +39,6 @@
     "webpack": "webpack --watch --config node_modules/@emulsify/core/config/webpack/webpack.dev.js"
   },
   "dependencies": {
-    "@emulsify/core": "^2.0.0"
+    "@emulsify/core": "^2.2.3"
   }
 }

--- a/whisk/whisk.info.emulsify.yml
+++ b/whisk/whisk.info.emulsify.yml
@@ -1,17 +1,17 @@
 type: theme
 base theme: emulsify
-core_version_requirement: "^10 || ^11"
+core_version_requirement: '^10 || ^11'
 
 name: whisk
 description: A subtheme build upon the Emulsify Design System.
-package: "Emulsify"
+package: 'Emulsify'
 screenshot: screenshot.png
 version: VERSION
 hidden: false
 
 dependencies:
-  - "drupal:components (^3.0)"
-  - "drupal:emulsify_tools (^4.0)"
+  - 'drupal:components (^3.0)'
+  - 'drupal:emulsify_tools (^4.0)'
 
 libraries:
   - whisk/base
@@ -25,15 +25,16 @@ regions:
 
 logo: assets/images/logo.svg
 
-components:
-  namespaces:
-    base: components/00-base
-    atoms: components/01-atoms
-    molecules: components/02-molecules
-    organisms: components/03-organisms
-    templates: components/04-templates
-    pages: components/05-pages
-    components: src/components
-    foundation: src/foundation
-    layout: src/layout
-    tokens: src/tokens
+# Uncomment the namespaces below that best fit your project.
+# components:
+#   namespaces:
+#     base: components/00-base
+#     atoms: components/01-atoms
+#     molecules: components/02-molecules
+#     organisms: components/03-organisms
+#     templates: components/04-templates
+#     pages: components/05-pages
+#     components: src/components
+#     foundation: src/foundation
+#     layout: src/layout
+#     tokens: src/tokens

--- a/whisk/whisk.info.emulsify.yml
+++ b/whisk/whisk.info.emulsify.yml
@@ -1,17 +1,17 @@
 type: theme
 base theme: emulsify
-core_version_requirement: '^10 || ^11'
+core_version_requirement: "^10 || ^11"
 
 name: whisk
 description: A subtheme build upon the Emulsify Design System.
-package: 'Emulsify'
+package: "Emulsify"
 screenshot: screenshot.png
 version: VERSION
 hidden: false
 
 dependencies:
-  - 'drupal:components (^3.0)'
-  - 'drupal:emulsify_tools (^4.0)'
+  - "drupal:components (^3.0)"
+  - "drupal:emulsify_tools (^4.0)"
 
 libraries:
   - whisk/base
@@ -33,3 +33,7 @@ components:
     organisms: components/03-organisms
     templates: components/04-templates
     pages: components/05-pages
+    components: src/components
+    foundation: src/foundation
+    layout: src/layout
+    tokens: src/tokens


### PR DESCRIPTION
**This PR does the following:**
- Updates emulsify/core to version `2.2.3`
- Updates whisk component namespaces to include a non-atomic component structure

### Ticket
- https://fourkitchens.clickup.com/t/36718269/EMULSIF-362

### Functional Testing:
- [ ] Review changes, make sure Emulsify Drupal functions as expected.


