### PR TITLE
feat: more twig template suggestions for views, users, forms, and fields

### DIFF
--- a/emulsify.libraries.yml
+++ b/emulsify.libraries.yml
@@ -1,5 +1,0 @@
-base:
-  version: VERSION
-  css:
-    theme:
-      dist/css/style.css: {}

--- a/emulsify.theme
+++ b/emulsify.theme
@@ -12,7 +12,7 @@
  *
  * @inheritdoc
  */
-function emulsify_suggestions_alter(&$suggestions, $variables, $hook) {
+function emulsify_theme_suggestions_alter(&$suggestions, $variables, $hook) {
   if ($hook == 'field') {
     $suggestions[] = 'field__' . $variables['element']['#entity_type'] . '__' . $variables['element']['#field_name'];
     $suggestions[] = 'field__' . $variables['element']['#entity_type'] . '__' . $variables['element']['#field_name'] . '__' . $variables['element']['#bundle'] . '__' . $variables['element']['#view_mode'];

--- a/whisk/whisk.info.emulsify.yml
+++ b/whisk/whisk.info.emulsify.yml
@@ -14,7 +14,7 @@ dependencies:
   - 'drupal:emulsify_tools (^4.0)'
 
 libraries:
-  - whisk/base
+  - whisk/global
 
 regions:
   header: Header

--- a/whisk/whisk.libraries.yml
+++ b/whisk/whisk.libraries.yml
@@ -1,5 +1,7 @@
-base:
+global:
   version: VERSION
   css:
     theme:
-      dist/css/style.css: { minified: true }
+      dist/global/foundation.css: { minified: true }
+      dist/global/layout.css: { minified: true }
+      dist/global/tokens.css: { minified: true }


### PR DESCRIPTION
**This PR does the following:**
- Removes Emulsify base theme library definition as it's not relevant to projects
- Enables useful twig template suggestions for Views, Users, Forms, and Fields
- Changes Whisk's base library to "global"

