### PR TITLE
fix: generate child theme name from project name

### DIFF
--- a/.github/scripts/release-check.cjs
+++ b/.github/scripts/release-check.cjs
@@ -861,6 +861,7 @@ function runStaticChecks() {
     ensure(!themeReadinessWorkflow.includes("Starterkit: build design tokens"), 'theme-readiness.yml should not assume generated themes use a design-token pipeline.');
     ensure(themeReadinessWorkflow.includes('timeout-minutes'), 'theme-readiness.yml should bound starterkit smoke phases with timeouts.');
     ensure(themeReadinessWorkflow.includes('Upload generated theme smoke artifacts'), 'theme-readiness.yml should upload generated theme smoke artifacts on failure.');
+    ensure(extractYamlValue(whiskInfo, 'name') === 'EMULSIFY_NAME', 'whisk.info.yml should keep the child theme name placeholder for Emulsify Tools generation.');
     ensure(extractYamlValue(whiskInfo, 'base theme') === 'emulsify', 'whisk.info.yml should keep emulsify as the generated child theme parent.');
     ensure(extractYamlValue(whiskInfo, 'hidden') === 'true', 'whisk.info.yml should remain hidden.');
     ensure(extractYamlValue(whiskInfoStarter, 'base theme') === 'emulsify', 'whisk.info.emulsify.yml should keep emulsify as the generated child theme parent.');

--- a/.github/scripts/starterkit-smoke.sh
+++ b/.github/scripts/starterkit-smoke.sh
@@ -108,6 +108,10 @@ generate_theme() {
     fail "Generated theme must use emulsify as its runtime parent theme."
   fi
 
+  if ! grep -Eq "^name:[[:space:]]*['\"]?${generated_theme}['\"]?[[:space:]]*$" "$generated_theme_info"; then
+    fail "Generated theme name must match the requested project name."
+  fi
+
   # Generated themes must be visible/installable and should not carry the source
   # theme's private starter metadata into consumer projects.
   if grep -Eq '^hidden:[[:space:]]*true[[:space:]]*$' "$generated_theme_info"; then

--- a/whisk/whisk.info.yml
+++ b/whisk/whisk.info.yml
@@ -2,7 +2,7 @@ type: theme
 base theme: emulsify
 core_version_requirement: '^11.3 || ^12'
 
-name: Whisk Starter
+name: EMULSIFY_NAME
 description: Generation-only starter source for Emulsify child themes.
 package: 'Emulsify'
 screenshot: screenshot.png


### PR DESCRIPTION
**This PR does the following:**
- Quick fix to update the `name` key in the `.info` file so it can be properly replaced.